### PR TITLE
DM-39074: Remove advertisement of UPLOAD methods from /capabilities XML

### DIFF
--- a/tap/src/main/webapp/capabilities.xml
+++ b/tap/src/main/webapp/capabilities.xml
@@ -161,9 +161,7 @@
         <alias>tsv</alias>
     </outputFormat>
 
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-inline"/>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-http"/>
-    <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-https"/>
+    <!-- We are not currently enabling any uploadMethod on Postgres-backed TAP -->
 
     <retentionPeriod>
         <default>7200</default>


### PR DESCRIPTION
Management decision to defer deployment of temporary-table UPLOADs in Postgres-backed TAP services
