### PR TITLE
[DM-39825] Try to get TAP UPLOAD to work

### DIFF
--- a/tap/src/main/java/ca/nrc/cadc/sample/QueryRunner.java
+++ b/tap/src/main/java/ca/nrc/cadc/sample/QueryRunner.java
@@ -140,7 +140,7 @@ public class QueryRunner implements JobRunner
 
     private static final String tapschemaSourceName = "jdbc/tapschemauser";
     private static final String tapDataSourceName = "jdbc/tapuser";
-    private static final String uploadDataSourceName = "jdbc/tapuploadadm";
+    private static final String uploadDataSourceName = "jdbc/tapuser";
 
     protected Job job;
     private JobUpdater jobUpdater;

--- a/tap/src/main/resources/PluginFactory.properties
+++ b/tap/src/main/resources/PluginFactory.properties
@@ -12,7 +12,7 @@ ca.nrc.cadc.tap.MaxRecValidator.impl = ca.nrc.cadc.sample.MaxRecValidatorImpl
 
 ca.nrc.cadc.tap.db.DatabaseDataType=ca.nrc.cadc.tap.pg.PostgresDataTypeMapper
 
-#ca.nrc.cadc.tap.UploadManager = ca.nrc.cadc.tap.DefaultUploadManager
+ca.nrc.cadc.tap.UploadManager = ca.nrc.cadc.tap.BasicUploadManager
 
 #ca.nrc.cadc.tap.TableWriter = ca.nrc.cadc.tap.DefaultTableWriter
 


### PR DESCRIPTION
In the PluginFactory, it used the "DefaultUploadManager," but even when that is called, it will say that "UPLOAD is not supported".

That's a bit tricky because technically it is supported in the capabilities, but this is a message that is emitted by the Upload Manager.  What we really need is the "BasicUploadManager."

In terms of the name of the account used for the TAP UPLOADS, Pat has suggested using the same account as for reads.  Otherwise I can change it back and use some of the .xml files to create a new named pool.  But it doesn't seem required at this point.