### PR TITLE
[DM-41951] set auto commit to false

### DIFF
--- a/tap/src/main/java/ca/nrc/cadc/sample/QueryRunner.java
+++ b/tap/src/main/java/ca/nrc/cadc/sample/QueryRunner.java
@@ -378,7 +378,7 @@ public class QueryRunner implements JobRunner
                     // manually control transaction, make fetch size (client batch size) small,
                     // and restrict to forward only so that client memory usage is minimal since
                     // we are only interested in reading the ResultSet once
-
+                    connection.setAutoCommit(false);
                     pstmt = connection.prepareStatement(sql);
                     pstmt.setFetchSize(1000);
                     pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);


### PR DESCRIPTION
This mimics a change  in lsst-tap-service to keep the memory usage small.  Setting the auto commit to false should get the jdbc driver to use the cursor mode when reading back results.  Without this it seems that the results of a query are currently fully read into memory before being returned.