### PR TITLE
Tickets DM-44524 - Enable CloudSQL UWS database for SSO TAP service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change log
+
+tap-postgres is versioned with [semver](https://semver.org/). Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
+
+Find changes for the upcoming release in the project's [changelog.d](https://github.com/lsst-sqre/tap-postgres/tree/main/changelog.d/).
+
+<!-- scriv-insert-here -->
+
+<a id='changelog-8.1.0'></a>
+## 1.16.0 (2024-05-30)
+
+### New features
+
+- Added UWSInitAction class, which can be used to initialise the database schema & tables for UWS. Modified the web.xml to run the class on initialisation
+
+
+### Bug fixes
+
+- Freeze the cadc-tap dependencies to the versions that came with the most recently released image, to address backwards incompatible changes in the most recent cadc-tap util package release

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,6 @@
 (cd tap && gradle clean assemble javadoc build test)
 cp tap/build/libs/tap-1.1.war docker/tap/tap.war
 
-(cd docker/tap && docker build . -t lsstdax/tap-postgres-server:dev)
+(cd docker/tap && docker build . -t lsstdax/tap-postgres-service:dev)
 (cd docker/cadc-postgresql-dev && docker build . -f Dockerfile.pg12 -t lsstdax/tap-postgres-db:dev)
 (cd docker/uws && docker build . -t lsstdax/tap-postgres-uws:dev)

--- a/changelog.d/_template.md
+++ b/changelog.d/_template.md
@@ -1,0 +1,7 @@
+<!-- Delete the sections that don't apply -->
+{%- for cat in config.categories %}
+
+### {{ cat }}
+
+-
+{%- endfor %}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   tap-service:
-    image: lsstdax/tap-postgres-server:dev
+    image: lsstdax/tap-postgres-service:dev
     depends_on:
       - tap-db
       - uws

--- a/push.sh
+++ b/push.sh
@@ -12,10 +12,10 @@ TAG=`echo "$TAG" | tr / _`
 
 echo "Pushing all images with tag $TAG"
 
-docker tag lsstdax/tap-postgres-server:dev lsstdax/tap-postgres-server:$TAG
+docker tag lsstdax/tap-postgres-service:dev lsstdax/tap-postgres-service:$TAG
 docker tag lsstdax/tap-postgres-db:dev lsstdax/tap-postgres-db:$TAG
 docker tag lsstdax/tap-postgres-uws:dev lsstdax/tap-postgres-uws:$TAG
 
-docker push lsstdax/tap-postgres-server:$TAG
+docker push lsstdax/tap-postgres-service:$TAG
 docker push lsstdax/tap-postgres-db:$TAG
 docker push lsstdax/tap-postgres-uws:$TAG

--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -17,16 +17,25 @@ version = '1.1'
 
 dependencies {
     implementation 'log4j:log4j:1.2.+'
-
-    implementation 'org.opencadc:cadc-log:[1.0,)'
-    implementation 'org.opencadc:cadc-util:[1.2,)'
-    implementation 'org.opencadc:cadc-dali:[1.1,)'
-    implementation 'org.opencadc:cadc-uws:[1.0,)'
-    implementation 'org.opencadc:cadc-uws-server:[1.2,)'
-    implementation 'org.opencadc:cadc-tap-server:[1.1.5,)'
-    implementation 'org.opencadc:cadc-vosi:[1.0,)'
-    implementation 'org.opencadc:cadc-adql:[1.1.13,)'
-
+    implementation 'org.opencadc:cadc-adql:1.1.13'
+    implementation 'org.opencadc:cadc-cdp:1.3.7'
+    implementation 'org.opencadc:cadc-dali:1.2.17'
+    implementation 'org.opencadc:cadc-dali-pg:0.3.1'
+    implementation 'org.opencadc:cadc-gms:1.0.12'
+    implementation 'org.opencadc:cadc-jsqlparser-compat:0.6.5'
+    implementation 'org.opencadc:cadc-log:1.2.1'
+    implementation 'org.opencadc:cadc-registry:1.7.6'
+    implementation 'org.opencadc:cadc-rest:1.3.18'
+    implementation 'org.opencadc:cadc-tap:1.1.16'
+    implementation 'org.opencadc:cadc-tap-schema:1.1.32'
+    implementation 'org.opencadc:cadc-tap-server:1.1.23'
+    implementation 'org.opencadc:cadc-tap-server-pg:1.0.5'
+    implementation 'org.opencadc:cadc-util:1.10.6'
+    implementation 'org.opencadc:cadc-uws:1.0.5'
+    implementation 'org.opencadc:cadc-uws-server:1.2.20'
+    implementation 'org.opencadc:cadc-tap-server:1.1.23'
+    implementation 'org.opencadc:cadc-vosi:1.4.4'
+    implementation 'org.opencadc:cadc-adql:1.1.13'
     // Switch out this to use any supported database instead of PostgreSQL.
     // ## START CUSTOM DATABASE ##
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.13'
@@ -45,3 +54,6 @@ configurations {
   runtime.exclude group: 'net.sourceforge.jtds'
   runtime.exclude group: 'org.restlet.jee'
 }
+
+
+

--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -54,6 +54,3 @@ configurations {
   runtime.exclude group: 'net.sourceforge.jtds'
   runtime.exclude group: 'org.restlet.jee'
 }
-
-
-

--- a/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
+++ b/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
@@ -1,0 +1,140 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2022.                            (c) 2022.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la "GNU Affero General Public
+*  License as published by the          License" telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package org.opencadc.sia2;
+
+import ca.nrc.cadc.db.DBUtil;
+import ca.nrc.cadc.rest.InitAction;
+import ca.nrc.cadc.uws.server.impl.InitDatabaseUWS;
+import javax.sql.DataSource;
+import org.apache.log4j.Logger;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ *
+ * @author pdowler
+ */
+public class UWSInitAction extends InitAction {
+    private static final Logger log = Logger.getLogger(UWSInitAction.class);
+
+    public UWSInitAction() { 
+    }
+
+    @Override
+    public void doInit() {
+        DataSource uws = null;
+        Connection conn = null;
+        try {
+            uws = DBUtil.findJNDIDataSource("jdbc/uws");
+            conn = uws.getConnection();
+            if (!schemaExists(conn, "uws")) {
+                createSchema(conn, "uws");
+                log.info("uws schema created");
+
+                // Continue with initialization only if the schema was just created
+                InitDatabaseUWS uwsi = new InitDatabaseUWS(uws, null, "uws");
+                uwsi.doInit();
+                log.info("init uws: OK");
+            } else {
+                log.info("uws schema already exists");
+                return; // Exit the method early if the schema already exists
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException("INIT FAIL", ex);
+        } finally {
+            if (conn != null) {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    log.error("Failed to close connection", e);
+                }
+            }
+        }
+    }
+
+    private boolean schemaExists(Connection conn, String schemaName) throws SQLException {
+        DatabaseMetaData dbMetaData = conn.getMetaData();
+        try (ResultSet rs = dbMetaData.getSchemas()) {
+            while (rs.next()) {
+                if (schemaName.equalsIgnoreCase(rs.getString("TABLE_SCHEM").trim())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void createSchema(Connection conn, String schemaName) throws SQLException {
+        try (java.sql.Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE SCHEMA " + schemaName);
+        }
+    }
+}

--- a/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
+++ b/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
@@ -65,7 +65,7 @@
 ************************************************************************
 */
 
-package org.opencadc.sia2;
+package org.opencadc.uws.impl;
 
 import ca.nrc.cadc.db.DBUtil;
 import ca.nrc.cadc.rest.InitAction;

--- a/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
+++ b/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
@@ -96,6 +96,7 @@ public class UWSInitAction extends InitAction {
             uws = DBUtil.findJNDIDataSource("jdbc/uws");
             conn = uws.getConnection();
             if (!schemaExists(conn, "uws")) {
+                log.info("uws schema does not exist, creating...");
                 createSchema(conn, "uws");
                 log.info("uws schema created");
 

--- a/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
+++ b/tap/src/main/java/ca/nrc/cadc/uws/impl/UWSInitAction.java
@@ -65,7 +65,7 @@
 ************************************************************************
 */
 
-package org.opencadc.uws.impl;
+package ca.nrc.cadc.uws.impl;
 
 import ca.nrc.cadc.db.DBUtil;
 import ca.nrc.cadc.rest.InitAction;
@@ -85,7 +85,7 @@ import java.sql.SQLException;
 public class UWSInitAction extends InitAction {
     private static final Logger log = Logger.getLogger(UWSInitAction.class);
 
-    public UWSInitAction() { 
+    public UWSInitAction() {
     }
 
     @Override

--- a/tap/src/main/webapp/WEB-INF/web.xml
+++ b/tap/src/main/webapp/WEB-INF/web.xml
@@ -134,6 +134,10 @@
         <servlet-name>SyncServlet</servlet-name>
         <servlet-class>ca.nrc.cadc.uws.server.JobServlet</servlet-class>
         <init-param>
+            <param-name>init</param-name>
+            <param-value>org.opencadc.sia2.UWSInitAction</param-value>
+        </init-param>
+        <init-param>
             <param-name>ca.nrc.cadc.uws.server.JobManager</param-name>
             <param-value>ca.nrc.cadc.sample.JobManager</param-value>
         </init-param>

--- a/tap/src/main/webapp/WEB-INF/web.xml
+++ b/tap/src/main/webapp/WEB-INF/web.xml
@@ -135,7 +135,7 @@
         <servlet-class>ca.nrc.cadc.uws.server.JobServlet</servlet-class>
         <init-param>
             <param-name>init</param-name>
-            <param-value>org.opencadc.uws.impl.UWSInitAction</param-value>
+            <param-value>ca.nrc.cadc.uws.impl.UWSInitAction</param-value>
         </init-param>
         <init-param>
             <param-name>ca.nrc.cadc.uws.server.JobManager</param-name>

--- a/tap/src/main/webapp/WEB-INF/web.xml
+++ b/tap/src/main/webapp/WEB-INF/web.xml
@@ -135,7 +135,7 @@
         <servlet-class>ca.nrc.cadc.uws.server.JobServlet</servlet-class>
         <init-param>
             <param-name>init</param-name>
-            <param-value>org.opencadc.sia2.UWSInitAction</param-value>
+            <param-value>org.opencadc.uws.impl.UWSInitAction</param-value>
         </init-param>
         <init-param>
             <param-name>ca.nrc.cadc.uws.server.JobManager</param-name>


### PR DESCRIPTION
**Description:**

Enable UWS schema & table initialization through the Java TAP service code. Introduce new class to do the init using https://github.com/lsst-sqre/dal-siav2/blob/master/sia2/src/main/java/org/opencadc/sia2/UWSInitAction.java and extend to add a check to skip process of schema already exists.

On top of above changes, modify "tap-server" to be "tap-service" in the Docker image create scripts. (Although this change doesn't really do anything, since the image is built from the .github workflow and the name is defined there)

**Relevant PR:**
https://rubinobs.atlassian.net/browse/DM-44524

**Detailed notes on approach:**
https://github.com/stvoutsin/rub-notes/wiki/DM%E2%80%9044427-%E2%80%90-Enable-CloudSQL-UWS-database-for-SSO-TAP-service