### PR TITLE
Fix issue with quoted column names in recent tap-postgres release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 
 <a id='changelog-1.17.1'></a>
-## 1.16.0 (2024-06-10)
+## 1.17.1 (2024-06-10)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
-<a id='changelog-8.1.0'></a>
+
+<a id='changelog-1.17.1'></a>
+## 1.16.0 (2024-06-10)
+
+### Fixed
+
+- Added PgsphereDeParser to AdqlQueryImpl / Fixes issue with queries having quotes around column names ("size")
+
+<a id='changelog-1.17.0'></a>
+## 1.17.0 (2024-06-07)
+
+## Changed
+
+- Bump cadc dependency versions & switch to using cadc-tomcat image by @stvoutsin in #28
+
+
+<a id='changelog-1.16.0'></a>
 ## 1.16.0 (2024-05-30)
 
 ### New features

--- a/changelog.d/20240610_190526_steliosvoutsinas_parser_fix.rst
+++ b/changelog.d/20240610_190526_steliosvoutsinas_parser_fix.rst
@@ -1,3 +1,0 @@
-Fixed
------
-- Added PgsphereDeParser to AdqlQueryImpl / Fixes issue with queries having quotes around column names ("size")

--- a/changelog.d/20240610_190526_steliosvoutsinas_parser_fix.rst
+++ b/changelog.d/20240610_190526_steliosvoutsinas_parser_fix.rst
@@ -1,0 +1,3 @@
+Fixed
+-----
+- Added PgsphereDeParser to AdqlQueryImpl / Fixes issue with queries having quotes around column names ("size")

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,2 @@
+[scriv]
+format = md

--- a/tap/src/main/java/ca/nrc/cadc/sample/AdqlQueryImpl.java
+++ b/tap/src/main/java/ca/nrc/cadc/sample/AdqlQueryImpl.java
@@ -72,6 +72,9 @@ package ca.nrc.cadc.sample;
 import ca.nrc.cadc.tap.AdqlQuery;
 import ca.nrc.cadc.tap.parser.converter.TableNameConverter;
 import ca.nrc.cadc.tap.parser.converter.TableNameReferenceConverter;
+import ca.nrc.cadc.tap.parser.BaseExpressionDeParser;
+import ca.nrc.cadc.tap.parser.PgsphereDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
 import ca.nrc.cadc.tap.parser.converter.TopConverter;
 import ca.nrc.cadc.tap.parser.navigator.ExpressionNavigator;
 import ca.nrc.cadc.tap.parser.navigator.FromItemNavigator;
@@ -117,4 +120,10 @@ public class AdqlQueryImpl extends AdqlQuery
 
         // TODO: add more custom query visitors here
     }
+
+    @Override
+    protected BaseExpressionDeParser getExpressionDeparser(SelectDeParser dep, StringBuffer sb) {
+        return new PgsphereDeParser(dep, sb);
+    }
+
 }

--- a/tap/src/test/java/ca/nrc/cadc/sample/AdqlQueryImplTest.java
+++ b/tap/src/test/java/ca/nrc/cadc/sample/AdqlQueryImplTest.java
@@ -168,18 +168,54 @@ public class AdqlQueryImplTest
         }
     }
     
+    // Test that a query using size works as expected (No quotes)
+    @Test
+    public void testQueryWithSizeConverter()
+    {
+        try
+        {
+            job.getParameterList().add(new Parameter("QUERY", "select top 5 * from test.tables as t"));
+
+            AdqlQueryImpl q = new AdqlQueryImpl();
+            q.setJob(job);
+            q.setTapSchema(mockTapSchema());
+
+            String sql = q.getSQL();
+            log.debug("SQL: " + sql);
+            Assert.assertNotNull("sql", sql);
+            sql = sql.toLowerCase();
+            int i = sql.indexOf("select") + 6;
+            int j = sql.indexOf("from") - 1;
+            String selectList = sql.substring(i, j);
+            log.debug("select-list: " + selectList);
+            Assert.assertTrue(selectList.contains("t.size"));
+        }
+        catch(Exception unexpected)
+        {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+        finally
+        {
+            job.getParameterList().clear();
+        }
+    }
+
     TapSchema mockTapSchema()
     {
         TapSchema ret = new TapSchema();
         SchemaDesc sd = new SchemaDesc("test");
         TableDesc foo = new TableDesc("test", "test.foo");
         TableDesc bar = new TableDesc("test", "test.bar");
+        TableDesc tables = new TableDesc("test", "test.tables");
         foo.getColumnDescs().add(new ColumnDesc("test.foo", "f1", TapDataType.INTEGER));
         foo.getColumnDescs().add(new ColumnDesc("test.foo", "f2", new TapDataType("char", "8", null)));
         bar.getColumnDescs().add(new ColumnDesc("test.bar", "b1", TapDataType.INTEGER));
         bar.getColumnDescs().add(new ColumnDesc("test.bar", "b2", new TapDataType("char", "8", null)));
+        tables.getColumnDescs().add(new ColumnDesc("test.tables", "size", new TapDataType("char", "8", null)));
         sd.getTableDescs().add(foo);
         sd.getTableDescs().add(bar);
+        sd.getTableDescs().add(tables);
         ret.getSchemaDescs().add(sd);
         return ret;
     }


### PR DESCRIPTION
**Description**
Following recent upgrades to newer cadc libs, there was a bug related to a Firefly query to get the columns from TAP_SCHEMA. The query produced included fetching the size column as "size" which is invalid in MySQL.This seems to be related to the upstream CADC work where they are moving out various parsing mechanisms into per-database specific implementations.

**Fix**
Fix was to add the PgsphereDeParser to the AdqlQueryImpl class, which was used previously but not by default after upgrades.

**Other changes:**
Also added scriv configuration file to default to md

**Related issue**
https://rubinobs.atlassian.net/browse/DM-44759
