### PR TITLE
Remove jcenter repo as it is obsolete and no longer used by cadc

### DIFF
--- a/changelog.d/20240813_193515_steliosvoutsinas_DM_45739.md
+++ b/changelog.d/20240813_193515_steliosvoutsinas_DM_45739.md
@@ -1,0 +1,7 @@
+### Removed
+
+- Remove jcenter repo as it is obsolete and no longer used by cadc
+
+### Other Changes
+
+- Added mavenCentral and jCenter repos (match what we have in lsst-tap-service)

--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -4,8 +4,9 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     mavenLocal()
+
     maven {
         url = 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/m2repo'
     }


### PR DESCRIPTION
**Summary:**

- Remove jcenter repo as it is obsolete and no longer used by cadc
- Remove org.restlet.jee:org.restlet.ext.servlet:2.0.3 no longer needed