### PR TITLE
Switch RubinUploadManagerImpl to use UploadLimits

### DIFF
--- a/changelog.d/20240820_185747_steliosvoutsinas_DM_45153.md
+++ b/changelog.d/20240820_185747_steliosvoutsinas_DM_45153.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Switch RubinUploadManagerImpl to use UploadLimits and set a default filesize limit of 32Mb

--- a/tap/src/main/java/ca/nrc/cadc/sample/RubinUploadManagerImpl.java
+++ b/tap/src/main/java/ca/nrc/cadc/sample/RubinUploadManagerImpl.java
@@ -68,16 +68,25 @@
 package ca.nrc.cadc.sample;
 
 import ca.nrc.cadc.tap.BasicUploadManager;
-
+import ca.nrc.cadc.tap.upload.UploadLimits;
 
 public class RubinUploadManagerImpl extends BasicUploadManager {
-
     /**
      * Default maximum number of rows allowed in the UPLOAD VOTable.
      */
     public static final int MAX_UPLOAD_ROWS = 100000;
 
+    public static final UploadLimits MAX_UPLOAD;
+
+    /**
+     * Use A filesize limit of 32 Mb using UploadLimits.
+     */
+    static {
+        MAX_UPLOAD = new UploadLimits(32 * 1024L * 1024L); // 32 Mb
+        MAX_UPLOAD.rowLimit = MAX_UPLOAD_ROWS;
+    }
+
     public RubinUploadManagerImpl() {
-        super(MAX_UPLOAD_ROWS);
+        super(MAX_UPLOAD);
     }
 }


### PR DESCRIPTION
**Summary**
Initializing UploadManager using just a rowcount (int) is deprecated. This PR switches to using the UploadLimits which is the new supported method of passing an upload limit.
We also specify an uploadsize of 32Mb.

**Jira ticket**
https://rubinobs.atlassian.net/browse/DM-45876