### PR TITLE
Enable storage of results in non-GCS S3 buckets

### DIFF
--- a/changelog.d/20240907_123946_steliosvoutsinas_DM_46074.md
+++ b/changelog.d/20240907_123946_steliosvoutsinas_DM_46074.md
@@ -1,0 +1,4 @@
+### Added
+
+- Support for S3 bucket storage of async results
+

--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 
     implementation 'com.google.cloud:google-cloud-storage:1.48.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    implementation 'software.amazon.awssdk:s3:2.17.230'
+    implementation 'software.amazon.awssdk:auth:2.17.230'
+    implementation 'org.apache.solr:solr-s3-repository:8.11.2'
+
     implementation 'org.antlr:ST4:4.3.1'
 
     testImplementation 'junit:junit:[4.0,)'


### PR DESCRIPTION
The tap-postgres TAP service until now only supported GCS buckets for storing async results.
This PR enables other S3 (non GCS) buckets via the use of aws S3 clients, similar to what was done for the lsst-tap-service.

**Jira Issue:**
https://rubinobs.atlassian.net/browse/DM-46074

**Tested with:**
https://github.com/stvoutsin/rspvalidator