### PR TITLE
Prepare release 1.18.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-1.18.7'></a>
+## 1.18.7 (2024-11-01)
+
+### Fixed
+
+- Enable non GCS S3 support for TAP_UPLOAD
+
 <a id='changelog-1.18.6'></a>
 ## 1.18.6 (2024-09-12)
 

--- a/changelog.d/20241101_002548_steliosvoutsinas_DM_47315.md
+++ b/changelog.d/20241101_002548_steliosvoutsinas_DM_47315.md
@@ -1,5 +1,0 @@
-<!-- Delete the sections that don't apply -->
-
-### Fixed
-
-- Enable non GCS S3 support for TAP_UPLOAD


### PR DESCRIPTION
Release 1.18.7:

- Enables non GCS S3 support for TAP_UPLOAD