### PR TITLE
Update cadc-gms version to 1.0.14

### DIFF
--- a/changelog.d/20241125_181022_steliosvoutsinas_DM_47788.md
+++ b/changelog.d/20241125_181022_steliosvoutsinas_DM_47788.md
@@ -1,0 +1,10 @@
+<!-- Delete the sections that don't apply -->
+
+### Changed
+
+- Updated version of gms to >=1.0.14
+
+
+### Fixed
+
+- Label warning in Docker build

--- a/docker/tap/Dockerfile
+++ b/docker/tap/Dockerfile
@@ -1,6 +1,6 @@
 FROM images.opencadc.org/library/cadc-tomcat:1
 
-LABEL org.opencontainers.image.source = "https://github.com/lsst-sqre/tap-postgres"
+LABEL org.opencontainers.image.source "https://github.com/lsst-sqre/tap-postgres"
 
 COPY *.war /usr/share/tomcat/webapps
 

--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation 'org.opencadc:cadc-adql:1.1.14'
     implementation 'org.opencadc:cadc-log:1.2.1'
-    implementation 'org.opencadc:cadc-gms:1.0.13'
+    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
     implementation 'org.opencadc:cadc-tap:1.1.16'
     implementation 'org.opencadc:cadc-tap:cadc-registry-1.7.6'
     implementation 'org.opencadc:cadc-tap:cadc-tap-1.1.16'


### PR DESCRIPTION
Bump version of cadc-gms to >=1.0.14 which uses the new OIDC discovery mechanism (looks for .well-known endpoint).
This requires an update to phalanx to set OIDC issuer to the base url of the RSP.