### PR TITLE
DM-48921: Upgrade a subset of the cadc dependencies

### DIFF
--- a/tap/build.gradle
+++ b/tap/build.gradle
@@ -22,25 +22,26 @@ configurations {
 }
 
 dependencies {
+
     implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
     implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-
-    implementation 'org.opencadc:cadc-adql:1.1.14'
-    implementation 'org.opencadc:cadc-log:1.2.1'
-    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
+    implementation 'org.opencadc:cadc-adql:[1.1.14,)'
+    implementation 'org.opencadc:cadc-log:[1.2.1,)'
+    implementation 'org.opencadc:cadc-gms:[1.0,)'
     implementation 'org.opencadc:cadc-tap:1.1.16'
-    implementation 'org.opencadc:cadc-tap:cadc-registry-1.7.6'
-    implementation 'org.opencadc:cadc-tap:cadc-tap-1.1.16'
+    implementation 'org.opencadc:cadc-tap:cadc-registry-[1.7.6,)'
     implementation 'org.opencadc:cadc-tap:cadc-tap-schema-1.1.33'
-    implementation 'org.opencadc:cadc-rest:1.3.20'
+    implementation 'org.opencadc:cadc-rest:[1.3.20,)'
     implementation 'org.opencadc:cadc-tap-server:1.1.24'
     implementation 'org.opencadc:cadc-tap-server-pg:1.1.0'
-    implementation 'org.opencadc:cadc-util:1.11.3'
-    implementation 'org.opencadc:cadc-uws:1.0.5'
-    implementation 'org.opencadc:cadc-uws-server:1.2.21'
-    implementation 'org.opencadc:cadc-vosi:1.4.6'
+    implementation 'org.opencadc:cadc-util:[1.11.3,)'
+    implementation 'org.opencadc:cadc-uws:[1.0.5,)'
+    implementation 'org.opencadc:cadc-uws-server:[1.2.21,)'
+    implementation 'org.opencadc:cadc-vosi:[1.0,2.0)'
+    implementation 'org.opencadc:cadc-dali:[1.0,1.2.18)'
+    implementation 'org.opencadc:cadc-dali-pg:0.3.1'
 
-
+    
     // Switch out this to use any supported database instead of PostgreSQL.
     // ## START CUSTOM DATABASE ##
     implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.4.0'


### PR DESCRIPTION
## Summary

Most of the the dependencies in the tap-postgres project were pinned to specific versions. This PR is a first step to bringing this up-to-date with the upstream CADC repo. The are a few dependencies that cannot be upgraded at the moment, as they depend on an update to the tap-schema schema itself.