### PR TITLE
DM-50058: Add tapadm to context and change TableServlet to use RestServlet similar to upstream

### DIFF
--- a/tap/src/main/webapp/META-INF/context.xml
+++ b/tap/src/main/webapp/META-INF/context.xml
@@ -3,6 +3,23 @@
 
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
 
+    <Resource name="jdbc/tapadm"
+              auth="Container"
+              type="javax.sql.DataSource"
+              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+              minEvictableIdleTimeMillis="30000"
+              maxActive="${tapschemauser.maxActive}" maxIdle="10" maxWait="20000" initialSize="5"
+              username="${tapschemauser.username}" password="${tapschemauser.password}"
+              driverClassName="${tapschemauser.driverClassName}"
+              url="${tapschemauser.url}"
+              removeAbandoned="false"
+              logAbandoned="true"
+              testOnBorrow="true"
+              testWhileIdle="true"
+              validationQuery="SELECT 1"
+              defaultAutoCommit="true"
+    />
+
     <Resource name="jdbc/tapschemauser"
               auth="Container"
               type="javax.sql.DataSource"

--- a/tap/src/main/webapp/WEB-INF/web.xml
+++ b/tap/src/main/webapp/WEB-INF/web.xml
@@ -196,11 +196,15 @@
     <!-- VOSI-tables provides an XML document describing the schema/tables/columns; 
          This implementation uses the TAP_SCHEMA to find the required metadata -->
     <servlet>
-        <load-on-startup>3</load-on-startup>
         <servlet-name>TableServlet</servlet-name>
-        <servlet-class>ca.nrc.cadc.sample.RubinTableServlet</servlet-class>
+        <servlet-class>ca.nrc.cadc.rest.RestServlet</servlet-class>
+        <init-param>
+            <param-name>get</param-name>
+            <param-value>ca.nrc.cadc.vosi.actions.GetAction</param-value>
+        </init-param>
+        <load-on-startup>3</load-on-startup>
     </servlet>
-    
+
     <servlet-mapping>
             <servlet-name>SyncServlet</servlet-name>
             <url-pattern>/sync/*</url-pattern>
@@ -233,7 +237,7 @@
     
     <servlet-mapping>
         <servlet-name>TableServlet</servlet-name>
-        <url-pattern>/tables</url-pattern>
+        <url-pattern>/tables/*</url-pattern>
     </servlet-mapping>
 	
     <!-- TODO: since this resource allows a POST to change the logging level, 


### PR DESCRIPTION
## Summary

The TableServlet class from the vosi package is now being replaced in the ustream repos. Instead we now use RestServlet, however this requires setting up a jdbc/tapadm resource in the context so in this PR we add this as well.